### PR TITLE
[ci, sival] Create a linter for the testplans

### DIFF
--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -39,3 +39,21 @@ jobs:
           suggest_fixes: 'false'
           config_file: ${{ env.verible_config }}
           extra_args: "--waiver_files=verible_waiver"
+  testplans-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install python dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install hjson jsonschema
+      - name: Run testplans linter action on hw/top_earlgrey/data
+        run: |
+          ./util/lint_testplan.py \
+            --dir hw/top_earlgrey/data \
+            --schema hw/lint/sival_testplan_schema.json
+      - name: Run testplans linter action on hw/top_earlgrey/data/ip
+        run: |
+          ./util/lint_testplan.py \
+            --dir hw/top_earlgrey/data/ip \
+            --schema hw/lint/sival_testplan_schema.json

--- a/hw/lint/sival_testplan_schema.json
+++ b/hw/lint/sival_testplan_schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "additionalProperties": false,
+    "testpoints": {
+      "type": "array",
+      "items": {
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "desc": {
+            "type": "string"
+          },
+          "stage": {
+            "enum": ["V1", "V2", "V2S", "V3"]
+          },
+          "si_stage": {
+            "enum": ["SV1", "SV2", "SV3", "SV4", "SV5", "NA", "None"]
+          },
+          "bazel": {
+            "type": "array"
+          },
+          "boot_stages": {
+            "type": "array",
+            "items": {
+              "enum": ["rom_ext", "silicon_owner"]
+            }
+          },
+          "lc_states": {
+            "type": "array",
+            "items": {
+              "enum": ["PROD", "TEST_UNLOCKED", "RAW", "SCRAP", "TEST_LOCKED",
+                "TEST_LOCKED0", "DEV", "RMA", "TEST_UNLOCKED0", "PROD_END"]
+            }
+          },
+          "features": {
+            "type": "array"
+          },
+          "tests": {
+            "type": "array"
+          },
+          "otp_mutate": {
+            "type": "boolean"
+          },
+          "host_support": {
+            "type": "boolean"
+          },
+          "tags": {
+            "type": "array"
+          }
+        },
+        "if": {
+          "properties": {
+            "si_stage": {
+              "not": {
+                "const": "NA"
+              }
+            }
+          }
+        },
+        "then": {
+          "required": ["bazel"]
+        },
+        "required": ["name", "desc", "stage", "si_stage", "tests"]
+      }
+    }
+  }
+}

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -121,6 +121,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
+      bazel: []
     }
     {
       name: chip_padctrl_attributes
@@ -140,6 +141,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_padctrl_attributes"]
+      bazel: []
     }
     {
       name: chip_sw_sleep_pin_mio_dio_val
@@ -182,6 +184,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sleep_pin_wake"]
+      bazel: []
     }
     {
       name: chip_sw_sleep_pin_retention
@@ -264,6 +267,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       tests: ["chip_sw_pattgen_ios"]
+      bazel: []
     }
 
     // PWM (pre-verified IP) integration tests:
@@ -381,6 +385,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_ast_clk_rst_inputs"]
+      bazel: []
     }
     {
       name: chip_sw_ast_sys_clk_jitter
@@ -401,6 +406,7 @@
               "chip_sw_kmac_mode_kmac_jitter_en",
               "chip_sw_sram_ctrl_scrambled_access_jitter_en",
               "chip_sw_edn_entropy_reqs_jitter"]
+      bazel: []
     }
     {
       name: chip_sw_ast_usb_clk_calib
@@ -421,6 +427,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_usb_ast_clk_calib"]
+      bazel: []
     }
 
     // SENSOR_CTRL tests:
@@ -452,6 +459,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_sensor_ctrl_status"]
+      bazel: []
     }
     {
       name: chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup
@@ -463,6 +471,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup"]
+      bazel: []
     }
 
     ////////////////////////////
@@ -745,6 +754,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_power_sleep_load"]
+      bazel: []
     }
 
     {

--- a/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_adc_ctrl_testplan.hjson
@@ -29,6 +29,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_sleep_debug_cable_wakeup
@@ -54,6 +55,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_adc_ctrl_sleep_debug_cable_wakeup"]
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_normal
@@ -63,6 +65,7 @@
       si_stage: SV2
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_adc_ctrl_oneshot
@@ -72,6 +75,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_aes_testplan.hjson
@@ -108,6 +108,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_aes_entropy
@@ -176,6 +177,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_aes_prng_reseed"]
+      bazel: []
     }
     {
       name: chip_sw_aes_force_prng_reseed
@@ -209,6 +211,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_aes_force_prng_reseed"]
+      bazel: []
     }
     {
       name: chip_sw_aes_idle

--- a/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_alert_handler_testplan.hjson
@@ -43,6 +43,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_escalation"]
+      bazel: []
       otp_mutate: true
       host_support: true
     }
@@ -67,6 +68,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
       otp_mutate: false
     }
     {
@@ -85,6 +87,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_all_escalation_resets
@@ -190,6 +193,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_alert_handler_lpg_sleep_mode_alerts"]
+      bazel: []
     }
     {
       name: chip_sw_alert_handler_lpg_sleep_mode_pings

--- a/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_clkmgr_testplan.hjson
@@ -149,7 +149,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_clkmgr_external_clk_src_for_lc"]
-      bazel: []
     }
     {
       name: chip_sw_clkmgr_external_clk_src_for_sw

--- a/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_entropy_src_testplan.hjson
@@ -79,7 +79,6 @@
       si_stage: NA
       lc_states: ["TEST_UNLOCKED", "PROD"]
       tests: ["chip_sw_entropy_src_fuse_en_fw_read_test"]
-      bazel: []
     },
     {
       name: chip_sw_entropy_src_known_answer_tests

--- a/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_flash_ctrl_testplan.hjson
@@ -94,6 +94,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_flash_rma_unlocked"]
+      bazel: []
     }
     {
       name: chip_sw_flash_scramble
@@ -251,6 +252,7 @@
       lc_states: ["DEV", "PROD", "PROD_END", "RMA"]
       boot_stages: ["rom_ext"]
       tests: ["chip_sw_flash_ctrl_lc_rw_en"]
+      bazel: []
     }
     {
       name: chip_sw_flash_lc_escalate_en

--- a/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_i2c_testplan.hjson
@@ -98,7 +98,8 @@
       stage: V3
       si_stage: SV3
       lc_states: ["PROD"]
-      tests: ["//sw/device/tests:i2c_host_override_test"]
+      tests: []
+      bazel: ["//sw/device/tests:i2c_host_override_test"]
     }
     {
       name: chip_sw_i2c_clockstretching

--- a/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_keymgr_testplan.hjson
@@ -43,6 +43,7 @@
         "chip_sw_keymgr_key_derivation",
         "chip_sw_keymgr_key_derivation_jitter_en",
       ]
+      bazel: []
     }
     {
       name: chip_sw_keymgr_sideload_kmac_error
@@ -160,16 +161,16 @@
             - The test should check for any error or fault code status, to ensure all operations
               executed successfully.
             '''
-            features: [
-              "KEYMGR.DERIVE.ATTESTATION",
-              "KEYMGR.GENERATE.OUTPUT",
-              "KEYMGR.GENERATE.IDENTITY",
-            ]
-            stage: V3
-            si_stage: SV2
-            lc_states: ["PROD"]
-            tests: []
-            bazel: []
+      features: [
+        "KEYMGR.DERIVE.ATTESTATION",
+        "KEYMGR.GENERATE.OUTPUT",
+        "KEYMGR.GENERATE.IDENTITY",
+      ]
+      stage: V3
+      si_stage: SV2
+      lc_states: ["PROD"]
+      tests: []
+      bazel: []
     }
     {
       name: chip_sw_keymgr_derive_sealing
@@ -183,17 +184,17 @@
             - Test a valid and an invalid key version when generating SW and sideload keys.
 
             '''
-            features: [
-              "KEYMGR.DERIVE.SEALING",
-              "KEYMGR.GENERATE.OUTPUT",
-              "KEYMGR.GENERATE.IDENTITY",
-              "KEYMGR.KEY_VERSIONING",
-            ]
-            stage: V3
-            si_stage: SV3
-            lc_states: ["PROD"]
-            tests: []
-            bazel: []
+      features: [
+        "KEYMGR.DERIVE.SEALING",
+        "KEYMGR.GENERATE.OUTPUT",
+        "KEYMGR.GENERATE.IDENTITY",
+        "KEYMGR.KEY_VERSIONING",
+      ]
+      stage: V3
+      si_stage: SV3
+      lc_states: ["PROD"]
+      tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_kmac_testplan.hjson
@@ -96,6 +96,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["chip_sw_kmac_entropy"]
+      bazel: []
     }
     {
       name: chip_sw_kmac_idle

--- a/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_lc_ctrl_testplan.hjson
@@ -288,11 +288,13 @@
              Verify that the features that should indeed be disabled are indeed disabled.
              '''
       stage: V2
+      si_stage: None
       tests: ["chip_sw_lc_walkthrough_dev",
               "chip_sw_lc_walkthrough_prod",
               "chip_sw_lc_walkthrough_prodend",
               "chip_sw_lc_walkthrough_rma",
               "chip_sw_lc_walkthrough_testunlocks"]
+      bazel: []
     }
     {
       name: chip_sw_lc_ctrl_volatile_raw_unlock

--- a/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_otp_ctrl_testplan.hjson
@@ -48,6 +48,7 @@
               "chip_sw_keymgr_key_derivation",
               "chip_sw_otbn_mem_scramble",
               "chip_sw_rv_core_ibex_icache_invalidate"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_entropy
@@ -68,6 +69,7 @@
               "chip_sw_keymgr_key_derivation",
               "chip_sw_otbn_mem_scramble",
               "chip_sw_rv_core_ibex_icache_invalidate"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_program
@@ -90,6 +92,7 @@
       si_stage: SV1
       lc_states: ["PROD"]
       tests: ["chip_sw_lc_ctrl_transition"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_program_error
@@ -180,6 +183,7 @@
       si_stage: SV3
       lc_states: ["TEST_UNLOCKED", "RMA"]
       tests: ["chip_prim_tl_access"]
+      bazel: []
     }
     {
       name: chip_sw_otp_ctrl_vendor_test_csr_access
@@ -232,6 +236,7 @@
       si_stage: SV1
       lc_states: ["TEST_UNLOCKED"]
       tests: []
+      bazel: []
     }
     {
       name: otp_ctrl_partition_access_locked

--- a/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_pwrmgr_testplan.hjson
@@ -196,7 +196,6 @@
         "PWRMGR.LOW_POWER.WAKE_INFO"
       ]
       tests: ["chip_sw_pwrmgr_sensor_ctrl_deep_sleep_wake_up"]
-      bazel: []
     }
     {
       name: chip_sw_pwrmgr_normal_sleep_all_reset_reqs
@@ -259,7 +258,6 @@
       stage: V2
       si_stage: NA
       tests: ["chip_sw_pwrmgr_full_aon_reset"]
-      bazel: []
     }
     {
       name: chip_sw_pwrmgr_main_power_glitch_reset

--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -77,6 +77,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
   ]
 }

--- a/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_core_ibex_testplan.hjson
@@ -222,6 +222,7 @@
      stage: V2S
      si_stage: None
      tests: ["chip_sw_rv_core_ibex_lockstep_glitch"]
+     bazel: []
     }
     {
       name: chip_sw_rv_core_ibex_alerts

--- a/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rv_dm_testplan.hjson
@@ -24,7 +24,7 @@
       tests: ["chip_jtag_csr_rw"]
       bazel: ["//sw/device/tests:rv_dm_csr_rw"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -55,7 +55,7 @@
       tests: ["chip_jtag_mem_access"]
       bazel: ["//sw/device/tests:rv_dm_mem_access"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -95,7 +95,7 @@
               "rom_e2e_jtag_debug_rma"]
       bazel: ["//sw/device/silicon_creator/rom/e2e/jtag_inject:rom_e2e_openocd_debug_test"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -119,7 +119,7 @@
       tests: ["chip_rv_dm_ndm_reset_req"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -151,7 +151,7 @@
       tests: ["chip_sw_rv_dm_ndm_reset_req_when_cpu_halted"]
       bazel: ["//sw/device/tests:rv_dm_ndm_reset_req_when_cpu_halted"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -172,7 +172,7 @@
       tests: ["chip_sw_rv_dm_access_after_wakeup"]
       bazel: ["//sw/device/tests:rv_dm_access_after_wakeup"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -209,7 +209,7 @@
       tests: ["chip_tap_straps_rma"]
       bazel: ["//sw/device/tests:rv_dm_jtag_tap_sel"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -255,7 +255,7 @@
       ],
       lc_states: ["RAW", "TEST_LOCKED", "TEST_UNLOCKED", "DEV", "RMA", "PROD",
         "PROD_END", "SCRAP"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM"
@@ -275,7 +275,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_jtag"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
       ]
@@ -294,7 +294,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_dtm"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",
@@ -325,7 +325,7 @@
       tests: []
       bazel: ["//sw/device/tests:rv_dm_control_status"],
       lc_states: ["DEV"]
-      host_support: "true"
+      host_support: true
       features: [
         "RV_DM.JTAG.FSM",
         "RV_DM.JTAG.DTM",

--- a/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_spi_host_testplan.hjson
@@ -54,6 +54,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: ["//sw/device/tests:spi_passthru_test"]
+      bazel: []
     }
     {
       name: chip_sw_spi_host_configuration
@@ -73,6 +74,7 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
+      bazel: []
     }
     {
       name: chip_sw_spi_host_events

--- a/hw/top_earlgrey/data/standalone_sw_testplan.hjson
+++ b/hw/top_earlgrey/data/standalone_sw_testplan.hjson
@@ -12,7 +12,9 @@
             It also performs a sanity region protection check to make sure a protected page cannot be modified.
             When the test passes, it will output "PASS!".'''
       stage: V1
+      si_stage: SV4
       tests: ["flash_test"]
+      bazel: []
     }
     {
       name: hmac
@@ -20,7 +22,9 @@
             It computes the hash of a known input and compares it against the known digest.
             When the test passes, it will output "PASS!".'''
       stage: V1
+      si_stage: SV4
       tests: ["sha256_test"]
+      bazel: []
     }
     {
       name: rv_timer
@@ -29,7 +33,9 @@
             If the interrupt handling is incorrect, the test will never complete.
             When the test passes, it will output "PASS!".'''
       stage: V1
+      si_stage: SV4
       tests: ["rv_timer_test"]
+      bazel: []
     }
   ]
 }

--- a/util/lint_testplan.py
+++ b/util/lint_testplan.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors (OpenTitan project).
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script lint the various opentitan testplan.hjson
+usage:
+    python3 ./util/lint_testplan.py --schema hw/lint/sival_testplan_schema.json \
+                                    --dir hw/top_earlgrey/data/ip/
+"""
+
+import argparse
+import glob
+import logging
+import sys
+import pathlib
+import hjson
+import json
+import jsonschema
+
+
+def main(args: argparse.Namespace) -> int:
+    files = [f for f in glob.glob(f"{args.dir}/*.hjson")]
+
+    assert args.schema
+    return Linter(args.schema).check(files)
+
+
+class Linter:
+    def __init__(self, schema_file: str):
+        self.schema = json.load(open(schema_file, "r", encoding="utf-8"))
+
+    def check(self, files: str) -> int:
+        res: int = 0
+        for f in files:
+            try:
+                testplan = hjson.load(open(f, "r", encoding="utf-8"))
+                jsonschema.validate(testplan, schema=self.schema)
+
+            except jsonschema.ValidationError as e:
+                logging.info("Validation failed on file %s: %s", f, e)
+                res = -1
+            except hjson.scanner.HjsonDecodeError as e:
+                logging.info("Failed to decode file %s: %s", f, e)
+                res = -1
+                break
+
+        if res == 0:
+            logging.info("No errors found!")
+        else:
+            logging.info("Errors found - run linting locally with %s", " ".join(sys.argv))
+        return res
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--logging",
+        default="info",
+        choices=["debug", "info", "warning", "error", "critical"],
+        help="Logging level",
+    )
+    parser.add_argument(
+        "--dir",
+        required=True,
+        help="A dir with all the testplan.hjson.",
+    )
+    parser.add_argument(
+        "--schema",
+        required=True,
+        type=pathlib.Path,
+        help="A json file with the linting rules to be used.",
+    )
+
+    args = parser.parse_args()
+    logging.basicConfig(level=args.logging.upper())
+    sys.exit(main(args))


### PR DESCRIPTION
A second PR to check testplan linting CI job running on a local fork to see if the github actions CI for the testplan linter is working as intended. Will force push with some errors to check that it fails properly as well.