### PR TITLE
[ci, sival] Create a linter for the testplans - Purposeful bad commit - EXPECTED FAIL

### DIFF
--- a/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
+++ b/hw/top_earlgrey/data/ip/chip_rom_ctrl_testplan.hjson
@@ -77,7 +77,6 @@
       si_stage: SV3
       lc_states: ["PROD"]
       tests: []
-      bazel: []
     }
   ]
 }


### PR DESCRIPTION
A bad commit that breaks the linting rules on a testplan. Should fail upon this PR being submitted. Used for testing purposes to check the github actions job is working as I intended.